### PR TITLE
Linked table of contents in PDF bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+ForneyLab.jl
 bundle/
 .ipynb_checkpoints
 Untitled.ipynb

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir -p /aip-5ssb0-bundler/lessons && \
     apt-add-repository ppa:staticfloat/juliareleases && \
     apt-get update && \
     apt-get install -y julia && \
-    pip3 install cython jupyter && \
+    pip3 install cython jupyter PyPDF2 && \
     julia -e 'Pkg.add("Cubature"); Pkg.add("DataFrames"); Pkg.add("Distributions"); Pkg.add("Interact"); Pkg.add("Optim"); Pkg.add("PyPlot"); Pkg.add("Reactive"); Pkg.add("IJulia")' && \
     apt-get autoremove -y && \
     apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ RUN mkdir -p /aip-5ssb0-bundler/lessons && \
     cd /aip-5ssb0-bundler && \
     npm install toc
 
+ADD ["ForneyLab.jl", "/root/.julia/v0.4/ForneyLab"]
+RUN julia -e 'Pkg.resolve()'
+
 VOLUME /aip-5ssb0-bundler/lessons
 VOLUME /aip-5ssb0-bundler/output
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN mkdir -p /aip-5ssb0-bundler/lessons && \
     apt-get update && \
     apt-get install -y build-essential \
                        curl \
+                       libjpeg-dev \
                        libnettle4 \
                        libzmq3-dev \
                        pkg-config \
@@ -26,11 +27,12 @@ RUN mkdir -p /aip-5ssb0-bundler/lessons && \
                        python3-pip \
                        python3-pyqt4 \
                        software-properties-common \
-                       subversion && \
+                       subversion \
+                       zlib1g-dev && \
     apt-add-repository ppa:staticfloat/juliareleases && \
     apt-get update && \
     apt-get install -y julia && \
-    pip3 install cython jupyter PyPDF2 && \
+    pip3 install cython jupyter PyPDF2 reportlab && \
     julia -e 'Pkg.add("Cubature"); Pkg.add("DataFrames"); Pkg.add("Distributions"); Pkg.add("Interact"); Pkg.add("Optim"); Pkg.add("PyPlot"); Pkg.add("Reactive"); Pkg.add("IJulia")' && \
     apt-get autoremove -y && \
     apt-get clean && \

--- a/README.md
+++ b/README.md
@@ -85,14 +85,26 @@ You can now open the lecture notes by going to the `IJulia` tab (press the refre
 
 ### Creating a PDF bundle of all lessons
 
-Install Docker from https://www.docker.com. Then from the root
-directory of the project issue
+This procedure will only be able to generate the PDF bundle for all lessons if
+ForneyLab is available as it is used for the later chapters. This is not
+publicly available software, so the functionality is limited for those who do
+not have access to it.
+
+Get ForneyLab.jl. Either clone it in the root of the project or modify the path
+in the Dockerfile to point at your own installation. If you do not have access
+to it, but do want to generate a PDF of the remaining lessons, just create an
+empty `ForneyLab.jl` directory.
+
+Install Docker from https://www.docker.com.
+
+Finally from the root directory of the project issue
 
 ```sh
 $ docker build -t aip-5ssb0-bundler .
 $ docker run --rm \
              --volume ${PWD}/lessons:/aip-5ssb0-bundler/lessons \
-             --volume ${PWD}/output:/aip-5sbb0-bundler/output aip-5ssb0-bundler
+             --volume ${PWD}/output:/aip-5sbb0-bundler/output \
+             aip-5ssb0-bundler
 ```
 
 to obtain a `bundle.pdf` file containing all lessons in the `output` directory.

--- a/bundler/bundle_configuration.py
+++ b/bundler/bundle_configuration.py
@@ -3,6 +3,8 @@ import PyPDF2, atexit, io, os, re, shutil
 from PyPDF2.generic import ArrayObject, NameObject, NumberObject
 from lxml import html
 from pathlib import Path
+from reportlab.pdfgen import canvas
+from reportlab.lib.pagesizes import A4
 
 build_directory = 'bundle'
 

--- a/bundler/bundle_configuration.py
+++ b/bundler/bundle_configuration.py
@@ -1,7 +1,8 @@
-import atexit, io, os, re, shutil
+import atexit, os, re, shutil
 
 from PyPDF2 import PdfFileReader, PdfFileWriter
 from PyPDF2.generic import ArrayObject, NameObject, NumberObject
+from io import BytesIO
 from lxml import html
 from pathlib import Path
 from reportlab.pdfgen import canvas
@@ -177,7 +178,7 @@ def concat_and_clean():
         target_pdf.appendPagesFromReader(source_pdf)
 
         # Manually add page numbers to the table of contents
-        toc_stream = io.StringIO()
+        toc_stream = BytesIO()
         toc_canvas = canvas.Canvas(toc_stream, pagesize = A4)
         current_page = 0
 

--- a/bundler/bundle_configuration.py
+++ b/bundler/bundle_configuration.py
@@ -1,5 +1,6 @@
-import PyPDF2, atexit, io, os, re, shutil
+import atexit, io, os, re, shutil
 
+from PyPDF2 import PdfFileReader, PdfFileWriter
 from PyPDF2.generic import ArrayObject, NameObject, NumberObject
 from lxml import html
 from pathlib import Path
@@ -119,7 +120,7 @@ def concat_and_clean():
         # be linked from. Then in the second pass, all links are updated to
         # point to the correct page and offset on that page based on the
         # information gathered in the first pass.
-        source_pdf = PyPDF2.PdfFileReader('output/AIP-5SSB0.pdf')
+        source_pdf = PdfFileReader('output/AIP-5SSB0.pdf')
 
         # Link dictionaries store links using their names as key with tuples
         # specifying their corresponding (page, ...) as values
@@ -172,7 +173,7 @@ def concat_and_clean():
                                 NameObject('/Rect'): ArrayObject([NumberObject(0), NumberObject(0), NumberObject(0), NumberObject(0)])
                             })
 
-        target_pdf = PyPDF2.PdfFileWriter()
+        target_pdf = PdfFileWriter()
         target_pdf.appendPagesFromReader(source_pdf)
 
         # Manually add page numbers to the table of contents
@@ -199,7 +200,7 @@ def concat_and_clean():
         toc_canvas.save()
 
         toc_stream.seek(0)
-        toc_pdf = PyPDF2.PdfFileReader(toc_stream)
+        toc_pdf = PdfFileReader(toc_stream)
         for page_number in range(1, toc_pdf.getNumPages()):
             target_page = target_pdf.getPage(page_number)
             target_page.mergePage(toc_pdf.getPage(page_number))

--- a/bundler/bundle_configuration.py
+++ b/bundler/bundle_configuration.py
@@ -1,5 +1,4 @@
-import atexit, os, re, shutil
-import PyPDF2
+import PyPDF2, atexit, io, os, re, shutil
 
 from PyPDF2.generic import ArrayObject, NameObject, NumberObject
 from lxml import html
@@ -175,7 +174,7 @@ def concat_and_clean():
         target_pdf.appendPagesFromReader(source_pdf)
 
         # Manually add page numbers to the table of contents
-        toc_stream = StringIO.StringIO()
+        toc_stream = io.StringIO()
         toc_canvas = canvas.Canvas(toc_stream, pagesize = A4)
         current_page = 0
 


### PR DESCRIPTION
These commits add links and page numbers to the PDF bundle.

There are some caveats which I don't think are worthwhile investigating at this time. First off in Chrome, the links will only move to the page an item is not, not exactly to the item. In all other applications I've checked (FireFox, Adobe Reader, Ubuntu's Document Viewer) the links do move you to the exact location of the item.

The second thing is that the font size of the page numbers does not match the font size of the rest of the document. For some reason trying to set it to a smaller value does not have any effect. They are still aligned correctly, just a bit larger than the table of contents items.